### PR TITLE
Deprecate this tap as formula has been added to Homebrew Core

### DIFF
--- a/Formula/lefthook.rb
+++ b/Formula/lefthook.rb
@@ -5,6 +5,8 @@ class Lefthook < Formula
   sha256 "f4247621abd7ee9860d8c18d6357077978f09e439bde9ff16462e3e743a93ee9"
   license "MIT"
 
+  deprecate! date: "2021-04-25", because: "has been accepted to Homebrew Core. Use `brew install lefthook` instead"
+
   bottle do
     root_url "https://github.com/evilmartians/homebrew-lefthook/releases/download/lefthook-0.7.4"
     sha256 cellar: :any_skip_relocation, catalina:     "88a4c54f3de5c09297fda72c17a29dce639d0bad329d01d3520c2b732ad8a308"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Homebrew Formulae for lefthook git hooks manager
 
+# This tap is deprecated!
+
+As `lefthook` formula has been added to Homebrew Core, install [Lefthook](https://github.com/evilmartians/lefthook) from there instead:
+
+```sh
+brew install lefthook
+```
+
 # How to publish new version in Homebrew
 
 Just create a PR with updated url and sha:


### PR DESCRIPTION
See https://docs.brew.sh/Deprecating-Disabling-and-Removing-Formulae

Homebrew core formula: https://github.com/Homebrew/homebrew-core/blob/master/Formula/lefthook.rb (was added in https://github.com/Homebrew/homebrew-core/pull/75706)

Console output:
```
$ brew install ./Formula/lefthook.rb 
Warning: lefthook has been deprecated because it has been accepted to Homebrew Core. Use `brew install lefthook` instead!
==> Downloading https://github.com/evilmartians/homebrew-lefthook/releases/download/lefthook-0.7.4/lefthook-0.7.4.x86_64_linux.bottle.tar.gz
Already downloaded: /home/envek/.cache/Homebrew/downloads/4528f41e64a1ab9fa69641c13d6b7d5807569e83e589ac4e6657c12a55e3d0b5--lefthook-0.7.4.x86_64_linux.bottle.tar.gz
==> Pouring lefthook-0.7.4.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/lefthook/0.7.4: 6 files, 7.8MB
```